### PR TITLE
調整提示卡片與圖示對齊

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -151,38 +151,58 @@ document.addEventListener('DOMContentLoaded', () => {
         const viewportHeight = window.innerHeight;
         const margin = 12;
 
-        let left = triggerRect.left + triggerRect.width / 2;
-        const halfWidth = tooltipWidth / 2;
-        if (left - halfWidth < margin) {
-            left = margin + halfWidth;
-        } else if (left + halfWidth > viewportWidth - margin) {
-            left = viewportWidth - margin - halfWidth;
-        }
-
+        const spaceLeft = triggerRect.left - margin;
+        const spaceRight = viewportWidth - triggerRect.right - margin;
         const spaceAbove = triggerRect.top - margin;
         const spaceBelow = viewportHeight - triggerRect.bottom - margin;
 
-        let placement = 'top';
+        const triggerVerticalCenter = triggerRect.top + triggerRect.height / 2;
+        const triggerHorizontalCenter = triggerRect.left + triggerRect.width / 2;
+
+        let placement = 'right';
+        let left;
         let top;
 
-        if (spaceAbove >= tooltipHeight || spaceAbove >= spaceBelow) {
-            placement = 'top';
-            top = Math.max(margin, triggerRect.top - margin - tooltipHeight);
-        } else {
+        if (spaceRight >= tooltipWidth || spaceRight >= spaceLeft) {
+            placement = 'right';
+            left = triggerRect.right + margin;
+            top = triggerVerticalCenter - tooltipHeight / 2;
+        } else if (spaceLeft >= tooltipWidth) {
+            placement = 'left';
+            left = triggerRect.left - margin - tooltipWidth;
+            top = triggerVerticalCenter - tooltipHeight / 2;
+        } else if (spaceBelow >= tooltipHeight || spaceBelow >= spaceAbove) {
             placement = 'bottom';
-            top = Math.min(viewportHeight - margin - tooltipHeight, triggerRect.bottom + margin);
+            left = triggerHorizontalCenter - tooltipWidth / 2;
+            top = triggerRect.bottom + margin;
+        } else {
+            placement = 'top';
+            left = triggerHorizontalCenter - tooltipWidth / 2;
+            top = triggerRect.top - margin - tooltipHeight;
         }
 
-        if (top < margin) {
-            top = margin;
-        }
-        if (top + tooltipHeight > viewportHeight - margin) {
-            top = Math.max(margin, viewportHeight - margin - tooltipHeight);
-        }
+        left = Math.min(Math.max(margin, left), viewportWidth - margin - tooltipWidth);
+        top = Math.min(Math.max(margin, top), viewportHeight - margin - tooltipHeight);
 
         panel.dataset.placement = placement;
         panel.style.left = `${left}px`;
         panel.style.top = `${top}px`;
+
+        if (placement === 'left' || placement === 'right') {
+            const arrowOffset = triggerVerticalCenter - top;
+            const minOffset = Math.min(tooltipHeight / 2, 12);
+            const maxOffset = tooltipHeight - minOffset;
+            const clampedOffset = Math.min(Math.max(arrowOffset, minOffset), maxOffset);
+            panel.style.setProperty('--tooltip-arrow-y', `${clampedOffset}px`);
+            panel.style.removeProperty('--tooltip-arrow-x');
+        } else {
+            const arrowOffset = triggerHorizontalCenter - left;
+            const minOffset = Math.min(tooltipWidth / 2, 12);
+            const maxOffset = tooltipWidth - minOffset;
+            const clampedOffset = Math.min(Math.max(arrowOffset, minOffset), maxOffset);
+            panel.style.setProperty('--tooltip-arrow-x', `${clampedOffset}px`);
+            panel.style.removeProperty('--tooltip-arrow-y');
+        }
     }
 
     function refreshTooltipPosition() {

--- a/templates/index.html
+++ b/templates/index.html
@@ -70,36 +70,54 @@
             border: 1px solid rgba(148, 163, 184, 0.35);
             box-shadow: 0 16px 40px rgba(15, 23, 42, 0.55);
             opacity: 0;
-            transform: translate(-50%, 0.35rem) scale(0.98);
+            transform: scale(0.98);
             pointer-events: none;
             transition: opacity 0.2s ease, transform 0.2s ease;
             text-align: left;
             z-index: 12000;
+            --tooltip-arrow-x: 50%;
+            --tooltip-arrow-y: 50%;
         }
 
         .tooltip-panel::after {
             content: '';
             position: absolute;
-            left: 50%;
-            transform: translateX(-50%);
             border-width: 6px;
             border-style: solid;
         }
 
         .tooltip-panel[data-visible="true"] {
             opacity: 1;
-            transform: translate(-50%, -0.35rem) scale(1);
+            transform: scale(1);
             pointer-events: auto;
         }
 
         .tooltip-panel[data-placement="top"]::after {
             top: 100%;
+            left: var(--tooltip-arrow-x);
+            transform: translateX(-50%);
             border-color: rgba(17, 24, 39, 0.95) transparent transparent transparent;
         }
 
         .tooltip-panel[data-placement="bottom"]::after {
             bottom: 100%;
+            left: var(--tooltip-arrow-x);
+            transform: translateX(-50%);
             border-color: transparent transparent rgba(17, 24, 39, 0.95) transparent;
+        }
+
+        .tooltip-panel[data-placement="left"]::after {
+            top: var(--tooltip-arrow-y);
+            right: -12px;
+            transform: translateY(-50%);
+            border-color: transparent rgba(17, 24, 39, 0.95) transparent transparent;
+        }
+
+        .tooltip-panel[data-placement="right"]::after {
+            top: var(--tooltip-arrow-y);
+            left: -12px;
+            transform: translateY(-50%);
+            border-color: transparent transparent transparent rgba(17, 24, 39, 0.95);
         }
 
         .styled-input {


### PR DESCRIPTION
## Summary
- 調整提示卡片樣式，移除固定位移並為不同方向提供箭頭與偏移變數
- 更新提示卡片定位邏輯，優先將卡片顯示在圖示左右並在必要時調整箭頭位置避免超出視窗

## Testing
- 未執行（前端樣式調整）

------
https://chatgpt.com/codex/tasks/task_e_68c95aa726308323926827ff0120b42b